### PR TITLE
[관리자] 고객 등록 - 이름 유효성 검사

### DIFF
--- a/src/main/resources/static/src/comm-validate.js
+++ b/src/main/resources/static/src/comm-validate.js
@@ -8,7 +8,7 @@ const regCheck = function(){
         frm.name.style.border = "1px solid gray";
     } else if(fName.test(frm.name.value) == false) {//test()로 유효성 검사 false
         alert("이름은 한글과 영문만 입력 가능합니다.");
-        frm.name.style.border = "1px solid red";
+        frm.name.value = '';
         frm.name.focus();
         return false; 
     }


### PR DESCRIPTION
## 구현내용
 + 고객 등록 페이지 - 이름 유효성 검사 #48

## 구현상세
 + 이름은 한글 또는 영문만 입력받는다
 + 영문은 대소문자를 구분하지 않는다.

## 구현사항 설명
+ 이름을 잘못 입력하고 등록 눌렀을 때 input태그에 빨간 테두리 쳐지는 속성 없앴습니다.

## 고민한 부분
+ 'keyup'을 사용하면 계속 alert창이 떠서 사용 안 했는데 이름 제대로 입력했을 때 테두리 속성 바꾸는 방법 있을까요🧐?