### PR TITLE
[관리자] 고객 관리페이지 - 비밀번호, 전화번호 유효성 검사

### DIFF
--- a/src/main/resources/static/admin-customer.html
+++ b/src/main/resources/static/admin-customer.html
@@ -165,7 +165,7 @@
           </div>
           <div class="rg-item">
             <span class="title">전화번호 *</span>
-            <input type="number" name="phone" class="write phone" placeholder="&nbsp;'-'없이 입력">
+            <input type="text" name="phone" class="write phone" placeholder="&nbsp;'-'없이 입력">
           </div>
           <div class="rg-item">
             <span class="title">성별</span>

--- a/src/main/resources/static/src/comm-validate.js
+++ b/src/main/resources/static/src/comm-validate.js
@@ -1,15 +1,15 @@
 'use strict';
 
 const frm = document.getElementById('reg_form'); //form id값 가져오기
-const fName = /^[가-힣a-zA-Z]+/; //정규식
-const fEmail = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
-const fPass = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@%^&*-]).{8,16}$/;
-const fPhone = /^[0-9]{2,3}[0-9]{3,4}[0-9]{4}/;
+const regName = /^[가-힣a-zA-Z]+/; //정규식
+const regEmail = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
+const regPass = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@%^&*-]).{8,16}$/;
+const regPhone = /^[0-9]{2,3}[0-9]{3,4}[0-9]{4}/;
 
 frm.addEventListener('submit', (e) => {
     e.preventDefault();
 //이름
-    if(fName.test(frm.name.value) == false) {//test()로 유효성 검사 false
+    if(regName.test(frm.name.value) == false) {//test()로 유효성 검사 false
         alert("이름은 한글과 영문만 입력 가능합니다.");
         frm.name.value = '';
         frm.name.focus();
@@ -17,7 +17,7 @@ frm.addEventListener('submit', (e) => {
     }
 
 //ID(이메일)
-    if(fEmail.test(frm.email.value) == false) {
+    if(regEmail.test(frm.email.value) == false) {
         alert("이메일 형태로 입력해주세요. \n이메일은 영문만 가능합니다. \n예시)abcd@efg.com");
         frm.email.value = '';
         frm.email.focus();
@@ -25,7 +25,7 @@ frm.addEventListener('submit', (e) => {
     }
 
 //비밀번호
-    if(fPass.test(frm.password.value) == false){
+    if(regPass.test(frm.password.value) == false){
         alert("비밀번호는 영문 대 소문+숫자+특수문자 8~16자리로 입력해주세요."+
         "\n특수문자 괄호(),<>는 사용 불가");
         frm.password.value = '';
@@ -34,7 +34,7 @@ frm.addEventListener('submit', (e) => {
     }
 
 //전화번호
-    if(fPhone.test(frm.phone.value) == false) {
+    if(regPhone.test(frm.phone.value) == false) {
         if(frm.phone.value.includes("-")) {
             alert("전화번호는 -없이 입력해주세요.");
             frm.phone.value = '';

--- a/src/main/resources/static/src/comm-validate.js
+++ b/src/main/resources/static/src/comm-validate.js
@@ -1,16 +1,15 @@
 'use strict';
 
-
 const frm = document.getElementById('reg_form'); //form id값 가져오기
 const fName = /^[가-힣a-zA-Z]+/; //정규식
 const fEmail = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
+const fPass = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@%^&*-]).{8,16}$/;
+const fPhone = /^[0-9]{2,3}[0-9]{3,4}[0-9]{4}/;
 
 frm.addEventListener('submit', (e) => {
     e.preventDefault();
 //이름
-    if(fName.test(frm.name.value) == true){ //test()로 유효성 검사 true
-        frm.name.style.border = "1px solid gray";
-    } else if(fName.test(frm.name.value) == false) {//test()로 유효성 검사 false
+    if(fName.test(frm.name.value) == false) {//test()로 유효성 검사 false
         alert("이름은 한글과 영문만 입력 가능합니다.");
         frm.name.value = '';
         frm.name.focus();
@@ -18,12 +17,35 @@ frm.addEventListener('submit', (e) => {
     }
 
 //ID(이메일)
-    if(fEmail.test(frm.email.value) == true) {
-        frm.email.style.border = "1px solid gray";
-    } else if(fEmail.test(frm.email.value) == false) {
-        alert("이메일 형태로 입력해주세요. \n이메일은 영문만 가능합니다.");
+    if(fEmail.test(frm.email.value) == false) {
+        alert("이메일 형태로 입력해주세요. \n이메일은 영문만 가능합니다. \n예시)abcd@efg.com");
         frm.email.value = '';
         frm.email.focus();
         return false;
     }
-});
+
+//비밀번호
+    if(fPass.test(frm.password.value) == false){
+        alert("비밀번호는 영문 대 소문+숫자+특수문자 8~16자리로 입력해주세요."+
+        "\n특수문자 괄호(),<>는 사용 불가");
+        frm.password.value = '';
+        frm.password.focus();
+        return false;
+    }
+
+//전화번호
+    if(fPhone.test(frm.phone.value) == false) {
+        if(frm.phone.value.includes("-")) {
+            alert("전화번호는 -없이 입력해주세요.");
+            frm.phone.value = '';
+            frm.phone.focus();
+            return false;
+        } else {
+            alert("전화번호는 숫자만 입력 가능합니다.");
+            frm.phone.value = '';
+            frm.phone.focus();
+            return false;
+        }
+    } 
+})
+


### PR DESCRIPTION
## 구현내용
 + 고객 관리페이지 - 비밀번호, 전화번호 유효성 검사 #87

## 구현상세
**<비밀번호>**
 + 영문 대소문자 구분하지 않는다.
 + 영문 대, 소문자, 숫자, 특수문자 조합해서 8~12자리로 입력 받는다.
 + 잘못 입력하고 등록 버튼 누르면 alert창으로 메시지 띄운다.
 + alert창 확인 버튼 누르면 input 박스에 포커스를 주고 값을 비운다.

**<전화번호>**
 + 숫자만 입력 받는다.
 + -(하이픈) 입력 시 alert창으로 메시지 띄운다.
 + 이외에는 비밀번호와 기능 동일하다.

## 구현사항 설명
+ 전화번호는 2가지 조건으로 나눔.
+ 1.-(하이픈)을 입력했을 경우와 
2.형식에 맞지 않게 입력했을 경우로 나눔